### PR TITLE
Ignore example files and non-svg icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+### Non-svg Icons ###
+/assets/icons/*.*
+!/assets/icons/*.svg
+
+### Local Example Files ###
+/_posts/*example*.md
+/_posts/*example*.markdown
+/_projects/*example*.md
+/_projects/*example*.markdown
+
 ### Jekyll ###
 _site
 .sass-cache


### PR DESCRIPTION
Ignore `_posts|_projects/*example*.md|markdown` and `assets/icons/*.*` `!assets/icons/*.svg`